### PR TITLE
Fix logfile name && write logfile to cwd rather than the location of the script

### DIFF
--- a/robotframework2testrail.py
+++ b/robotframework2testrail.py
@@ -17,7 +17,7 @@ from testrail_utils import TestRailApiUtils
 
 # pylint: disable=logging-format-interpolation
 
-PATH = os.path.abspath(os.path.dirname(__file__))
+PATH = os.getcwd()
 
 COMMENT_SIZE_LIMIT = 1000
 

--- a/robotframework2testrail.py
+++ b/robotframework2testrail.py
@@ -23,7 +23,7 @@ COMMENT_SIZE_LIMIT = 1000
 
 # Configure the logging
 LOG_FORMAT = '%(asctime)-15s %(levelname)-10s %(message)s'
-logging.basicConfig(filename=os.path.join(PATH, 'robotframwork2testrail.log'), format=LOG_FORMAT, level=logging.DEBUG)
+logging.basicConfig(filename=os.path.join(PATH, 'robotframework2testrail.log'), format=LOG_FORMAT, level=logging.DEBUG)
 CONSOLE_HANDLER = logging.StreamHandler()
 CONSOLE_HANDLER.setLevel(logging.INFO)
 CONSOLE_HANDLER.setFormatter(logging.Formatter('%(message)s'))


### PR DESCRIPTION
Title says it all really.

1. Fix logfile name `robotframwork...` to `robotframework...`
2. Write logfile to `cwd`, usually the project we're I'm running the script rather than the location of the script (we copy the scripts into a location on the `$PATH`)