### PR TITLE
Fix robotframework2testrail.py to handle the new get_tests API

### DIFF
--- a/robotframework2testrail.py
+++ b/robotframework2testrail.py
@@ -121,9 +121,17 @@ def publish_results(api, testcases, run_id=0, plan_id=0, version='', publish_blo
     """
     if run_id:
         if api.is_testrun_available(run_id):
-            count = 0
             logging.info('Publish in Test Run #%d', run_id)
-            testcases_in_testrun_list = api.get_tests(run_id)
+            test_offset = 0
+            tests_requested = 100
+            tests_left = True
+            testcases_in_testrun_list = []
+            while(tests_left):
+                    testcases_from_testrail = api.get_tests(run_id, tests_requested, test_offset)
+                    if (testcases_from_testrail['size'] == 0):
+                            break
+                    testcases_in_testrun_list += testcases_from_testrail['tests']
+                    test_offset += (testcases_from_testrail['size'])
 
             # Filter tests present in Test Run
             case_id_in_testrun_list = [str(tc['case_id']) for tc in testcases_in_testrun_list]

--- a/testrail_utils.py
+++ b/testrail_utils.py
@@ -131,7 +131,7 @@ class TestRailApiUtils(testrail.APIClient):
 
         return testcase_id
 
-    def get_tests(self, testrun_id):
+    def get_tests(self, testrun_id, testcase_limit, testcase_offset):
         """ Return the list of tests containing in a Test Run,
             starting at testcase_offset and returning max testcase_limit tests
 

--- a/testrail_utils.py
+++ b/testrail_utils.py
@@ -10,13 +10,13 @@ API_ADD_RESULT_CASE_URL = 'add_result_for_case/{run_id}/{case_id}'
 API_ADD_RESULT_CASES_URL = 'add_results_for_cases/{run_id}'
 API_GET_RUN_URL = 'get_run/{run_id}'
 API_GET_PLAN_URL = 'get_plan/{plan_id}'
-API_GET_TESTS_URL = 'get_tests/{run_id}'
+API_GET_TESTS_URL = 'get_tests/{run_id}&limit={limit}&offset={offset}'
 
 ROBOTFWK_TO_TESTRAIL_STATUS = {
     "PASS": 1,
+    "SKIP": 4,
     "FAIL": 5,
 }
-
 
 class TestRailApiUtils(testrail.APIClient):
     """ Class adding facilities to manipulate Testrail API """
@@ -132,12 +132,15 @@ class TestRailApiUtils(testrail.APIClient):
         return testcase_id
 
     def get_tests(self, testrun_id):
-        """ Return the list of tests containing in a Test Run.
+        """ Return the list of tests containing in a Test Run,
+            starting at testcase_offset and returning max testcase_limit tests
 
         :param testrun_id: TestRail ID of the Test Run
+        :param testcase_limit: max tests to return for request
+        :param testcase_offset: start offset for request
 
         """
         try:
-            return self.send_get(API_GET_TESTS_URL.format(run_id=testrun_id))
+            return self.send_get(API_GET_TESTS_URL.format(run_id=testrun_id, limit=testcase_limit, offset=testcase_offset))
         except testrail.APIError as error:
             logging.error(error)


### PR DESCRIPTION
api.get_tests() improved in order to handle the new paging API. 

Thanks to Seppo Korpelainen on discuss.gurock.com

See https://discuss.gurock.com/t/getcases-api-cannot-understand-iterating-jarray-noob-question/19639/8